### PR TITLE
Update to paimon-0.8-SNAPSHOT And presto-0.287

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ After the packaging is complete, you can choose the corresponding connector base
 |-----------------|-------------------------------------------------------------------------------|
 | [0.236, 0.268)  | `./paimon-presto-0.236/target/paimon-presto-0.236-0.7-SNAPSHOT-plugin.tar.gz` |
 | [0.268, 0.273)  | `./paimon-presto-0.268/target/paimon-presto-0.268-0.7-SNAPSHOT-plugin.tar.gz` |
-| [0.273, latest] | `./paimon-presto-0.273/target/paimon-presto-0.273-0.7-SNAPSHOT-plugin.tar.gz` |
+| [0.273, 0.287] | `./paimon-presto-0.273/target/paimon-presto-0.273-0.7-SNAPSHOT-plugin.tar.gz` |
+| [0.287, latest] | `./paimon-presto-0.287/target/paimon-presto-0.287-0.8-SNAPSHOT-plugin.tar.gz` |
 
 Of course, we also support different versions of Hive and Hadoop. But note that we utilize 
 Presto-shaded versions of Hive and Hadoop packages to address dependency conflicts. 

--- a/paimon-presto-0.287/pom.xml
+++ b/paimon-presto-0.287/pom.xml
@@ -18,104 +18,57 @@ specific language governing permissions and limitations
 under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>paimon-presto</artifactId>
         <groupId>org.apache.paimon</groupId>
+        <artifactId>paimon-presto</artifactId>
         <version>0.8-SNAPSHOT</version>
     </parent>
-
-    <packaging>jar</packaging>
-
-    <artifactId>paimon-presto-common</artifactId>
-    <name>Paimon : Presto : Common</name>
-
+    <modelVersion>4.0.0</modelVersion>
+    
+    <artifactId>paimon-presto-0.287</artifactId>
+    <name>Paimon : Presto : 0.287</name>
+    
     <properties>
         <presto.version>0.287</presto.version>
         <hadoop.apache2.version>2.7.4-12</hadoop.apache2.version>
-        <hive.apache.version>3.0.0-10</hive.apache.version>
-        <airlift.version>0.209</airlift.version>
-        <libthrift.version>0.9.3</libthrift.version>
     </properties>
-
+    
     <dependencies>
-
-        <!-- see https://mvnrepository.com/artifact/com.facebook.presto.hadoop/hadoop-apache2 -->
         <dependency>
-            <groupId>com.facebook.presto.hadoop</groupId>
-            <artifactId>hadoop-apache2</artifactId>
-            <version>${hadoop.apache2.version}</version>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-presto-common</artifactId>
+            <version>${project.version}</version>
         </dependency>
-
-        <!-- see https://mvnrepository.com/artifact/com.facebook.presto.hive/hive-apache -->
-        <dependency>
-            <groupId>com.facebook.presto.hive</groupId>
-            <artifactId>hive-apache</artifactId>
-            <version>${hive.apache.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-hive</artifactId>
-            <version>${presto.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libthrift</artifactId>
-            <version>${libthrift.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.airlift</groupId>
-            <artifactId>configuration</artifactId>
-            <version>${airlift.version}</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.airlift</groupId>
-            <artifactId>bootstrap</artifactId>
-            <version>${airlift.version}</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.airlift</groupId>
-            <artifactId>json</artifactId>
-            <version>${airlift.version}</version>
-            <scope>compile</scope>
-        </dependency>
-
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
             <version>${presto.version}</version>
+            <scope>provided</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>
             <version>${presto.version}</version>
+            <scope>provided</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-plugin-toolkit</artifactId>
             <version>${presto.version}</version>
             <scope>provided</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-client</artifactId>
             <version>${presto.version}</version>
             <scope>test</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
@@ -136,7 +89,7 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
-
+        
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
@@ -153,12 +106,27 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-main</artifactId>
-            <version>0.273</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-
+    
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.5</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/paimon.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attached</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/paimon-presto-0.287/src/main/assembly/paimon.xml
+++ b/paimon-presto-0.287/src/main/assembly/paimon.xml
@@ -1,0 +1,32 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+    <id>plugin</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>paimon</outputDirectory>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@ under the License.
         <module>paimon-presto-0.236</module>
         <module>paimon-prestosql-common</module>
         <module>paimon-prestosql-332</module>
+        <module>paimon-presto-0.287</module>
     </modules>
 
     <parent>
@@ -40,7 +41,7 @@ under the License.
     <groupId>org.apache.paimon</groupId>
     <artifactId>paimon-presto</artifactId>
     <name>Paimon : Presto</name>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.8-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
更新pom中presto版本为0.287,paimon为0.8,已测试presto-0.287可用