### PR TITLE
Expose metrics for paimon presto reader

### DIFF
--- a/paimon-presto-0.236/src/test/java/org/apache/paimon/presto/SimpleTableTestHelper.java
+++ b/paimon-presto-0.236/src/test/java/org/apache/paimon/presto/SimpleTableTestHelper.java
@@ -41,7 +41,7 @@ public class SimpleTableTestHelper {
 
     public SimpleTableTestHelper(Path path, RowType rowType) throws Exception {
         Map<String, String> options = new HashMap<>();
-        options.put("bucket", "2");
+        options.put("bucket", "1");
         new SchemaManager(LocalFileIO.create(), path)
                 .createTable(
                         new Schema(

--- a/paimon-presto-0.268/src/test/java/org/apache/paimon/presto/SimpleTableTestHelper.java
+++ b/paimon-presto-0.268/src/test/java/org/apache/paimon/presto/SimpleTableTestHelper.java
@@ -23,6 +23,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -44,7 +45,7 @@ public class SimpleTableTestHelper {
                                 rowType.getFields(),
                                 Collections.emptyList(),
                                 Collections.singletonList("a"),
-                                Collections.emptyMap(),
+                                ImmutableMap.of("bucket", "1"),
                                 ""));
         FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), path);
         String user = "user";

--- a/paimon-presto-0.268/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
+++ b/paimon-presto-0.268/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
@@ -24,6 +24,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -130,7 +131,7 @@ public class TestPrestoITCase {
                                     rowType.getFields(),
                                     Collections.emptyList(),
                                     Collections.singletonList("i"),
-                                    new HashMap<>(),
+                                    ImmutableMap.of("bucket", "1"),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath4);
             InnerTableWrite writer = table.newWrite("user");

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/SimpleTableTestHelper.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/SimpleTableTestHelper.java
@@ -23,6 +23,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -44,7 +45,7 @@ public class SimpleTableTestHelper {
                                 rowType.getFields(),
                                 Collections.emptyList(),
                                 Collections.singletonList("a"),
-                                Collections.emptyMap(),
+                                ImmutableMap.of("bucket", "1"),
                                 ""));
         FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), path);
         String user = "user";

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
@@ -26,6 +26,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -143,7 +144,7 @@ public class TestPrestoITCase {
                                     rowType.getFields(),
                                     Collections.emptyList(),
                                     Collections.singletonList("i"),
-                                    new HashMap<>(),
+                                    ImmutableMap.of("bucket", "1"),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath4);
             InnerTableWrite writer = table.newWrite("user");
@@ -174,7 +175,7 @@ public class TestPrestoITCase {
                                     rowType.getFields(),
                                     Collections.emptyList(),
                                     Collections.singletonList("ts"),
-                                    new HashMap<>(),
+                                    ImmutableMap.of("bucket", "1"),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath5);
             InnerTableWrite writer = table.newWrite("user");
@@ -204,7 +205,7 @@ public class TestPrestoITCase {
                                     rowType.getFields(),
                                     Collections.emptyList(),
                                     Arrays.asList("c1", "c2"),
-                                    new HashMap<>(),
+                                    ImmutableMap.of("bucket", "1"),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath5);
             InnerTableWrite writer = table.newWrite("user");

--- a/paimon-prestosql-332/src/test/java/org/apache/paimon/prestosql/SimpleTableTestHelper.java
+++ b/paimon-prestosql-332/src/test/java/org/apache/paimon/prestosql/SimpleTableTestHelper.java
@@ -23,6 +23,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -44,7 +45,7 @@ public class SimpleTableTestHelper {
                                 rowType.getFields(),
                                 Collections.emptyList(),
                                 Collections.singletonList("a"),
-                                Collections.emptyMap(),
+                                ImmutableMap.of("bucket", "1"),
                                 ""));
         FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), path);
         String user = "user";

--- a/paimon-prestosql-332/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlITCase.java
+++ b/paimon-prestosql-332/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlITCase.java
@@ -24,6 +24,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -104,7 +105,7 @@ public class TestPrestoSqlITCase extends AbstractTestQueryFramework {
                                     rowType.getFields(),
                                     Collections.singletonList("pt"),
                                     Collections.emptyList(),
-                                    new HashMap<>(),
+                                    ImmutableMap.of("bucket", "1"),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath3);
             InnerTableWrite writer = table.newWrite("user");
@@ -133,7 +134,7 @@ public class TestPrestoSqlITCase extends AbstractTestQueryFramework {
                                     rowType.getFields(),
                                     Collections.emptyList(),
                                     Collections.singletonList("i"),
-                                    new HashMap<>(),
+                                    ImmutableMap.of("bucket", "1"),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath4);
             InnerTableWrite writer = table.newWrite("user");

--- a/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/SimpleTableTestHelper.java
+++ b/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/SimpleTableTestHelper.java
@@ -23,6 +23,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -44,7 +45,7 @@ public class SimpleTableTestHelper {
                                 rowType.getFields(),
                                 Collections.emptyList(),
                                 Collections.singletonList("a"),
-                                Collections.emptyMap(),
+                                ImmutableMap.of("bucket", "1"),
                                 ""));
         FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), path);
         String user = "user";

--- a/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlTCase.java
+++ b/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlTCase.java
@@ -25,6 +25,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -105,7 +106,7 @@ public class TestPrestoSqlTCase extends AbstractTestQueryFramework {
                                     rowType.getFields(),
                                     Collections.singletonList("pt"),
                                     Collections.emptyList(),
-                                    new HashMap<>(),
+                                    ImmutableMap.of("bucket", "1"),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath3);
             InnerTableWrite writer = table.newWrite("user");
@@ -134,7 +135,7 @@ public class TestPrestoSqlTCase extends AbstractTestQueryFramework {
                                     rowType.getFields(),
                                     Collections.emptyList(),
                                     Collections.singletonList("i"),
-                                    new HashMap<>(),
+                                    ImmutableMap.of("bucket", "1"),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath4);
             InnerTableWrite writer = table.newWrite("user");


### PR DESCRIPTION
Add metrics for the presto reader. 
After this, the IO metrics could be shown in presto web ui


<img width="266" alt="image" src="https://github.com/user-attachments/assets/ed8844de-3be3-46a6-9ce8-d4c029a56988">
